### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21982,6 +21982,26 @@ INVERT
 
 ================================
 
+themetaphysicalcompass.com
+
+CSS
+.tdi_188_rand_style {
+opacity:0!important;
+}
+.tdi_180_rand_style {
+opacity:0!important;
+}
+.tdi_182_rand_style {
+opacity:0!important;
+}
+.tdi_113_rand_style {
+opacity:0!important;
+}
+.tdi_258_rand_style{
+opacity:0.3!important;
+}
+
+================================
 themoscowtimes.com
 moscowtimes.ru
 


### PR DESCRIPTION
Added the following code to fix some background images in posts that use certain templates:

================================

themetaphysicalcompass.com

CSS
.tdi_188_rand_style {
opacity:0!important;
}
.tdi_180_rand_style {
opacity:0!important;
}
.tdi_182_rand_style {
opacity:0!important;
}
.tdi_113_rand_style {
opacity:0!important;
}
.tdi_258_rand_style{
opacity:0.4!important;
}

================================